### PR TITLE
Add SplittingStrategy to the init

### DIFF
--- a/extract_thinker/__init__.py
+++ b/extract_thinker/__init__.py
@@ -15,6 +15,7 @@ from .image_splitter import ImageSplitter
 from .text_splitter import TextSplitter
 from .models.classification import Classification
 from .models.contract import Contract
+from .models.splitting_strategy import SplittingStrategy
 
 
 __all__ = [


### PR DESCRIPTION
Related to #50

Add `SplittingStrategy` to the import statements and `__all__` list in `extract_thinker/__init__.py`.

* Add `from .models.splitting_strategy import SplittingStrategy` to the import statements.
* Add `SplittingStrategy` to the `__all__` list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/enoch3712/ExtractThinker/issues/50?shareId=6d045fa6-083a-4be3-9456-5e999be40813).