### PR TITLE
Add can_handle logic for DocumentLoader

### DIFF
--- a/extract_thinker/__init__.py
+++ b/extract_thinker/__init__.py
@@ -9,12 +9,12 @@ from .document_loader.document_loader_azure_document_intelligence import Documen
 from .document_loader.document_loader_pypdf import DocumentLoaderPyPdf
 from .document_loader.document_loader_pdfplumber import DocumentLoaderPdfPlumber
 from .document_loader.beautiful_soup_web_loader import DocumentLoaderBeautifulSoup
-from .models import classification, classification_response
+from .models.classification import Classification
+from .models.classification_response import ClassificationResponse
 from .process import Process
 from .splitter import Splitter
 from .image_splitter import ImageSplitter
 from .text_splitter import TextSplitter
-from .models.classification import Classification
 from .models.contract import Contract
 from .models.splitting_strategy import SplittingStrategy
 from .batch_job import BatchJob
@@ -30,14 +30,13 @@ __all__ = [
     'DocumentLoaderPyPdf',
     'DocumentLoaderPdfPlumber',
     'DocumentLoaderBeautifulSoup',
-    'classification',
-    'classification_response',
+    'Classification',
+    'ClassificationResponse',
     'Process',
     'ClassificationStrategy',
     'Splitter',
     'ImageSplitter',
     'TextSplitter',
-    'Classification',
     'Contract',
     'SplittingStrategy',
 	'BatchJob'

--- a/extract_thinker/document_loader/document_loader.py
+++ b/extract_thinker/document_loader/document_loader.py
@@ -73,7 +73,7 @@ class DocumentLoader(ABC):
     def getContent(self) -> Any:
         return self.content
 
-    def load_content_list(self, input_data: Union[str, BytesIO, List[Union[str, BytesIO]]]) -> Union[str, List[str]]:
+    def load_content_list(self, input_data: Union[str, BytesIO, List[Union[str, BytesIO]]]) -> Union[str, List[str]]:  
         if isinstance(input_data, (str, BytesIO)):
             return self.load_content_from_stream_list(input_data)
         elif isinstance(input_data, list):
@@ -90,8 +90,6 @@ class DocumentLoader(ABC):
         pass
 
     def convert_to_images(self, file: Union[str, io.BytesIO], scale: float = 300 / 72) -> Dict[int, bytes]:
-        if not self.can_handle(file):
-            raise ValueError("Unsupported file type or stream.")
         # Determine if the input is a file path or a stream
         if isinstance(file, str):
             return self._convert_file_to_images(file, scale)

--- a/extract_thinker/document_loader/document_loader.py
+++ b/extract_thinker/document_loader/document_loader.py
@@ -16,23 +16,42 @@ class DocumentLoader(ABC):
         self.cache = TTLCache(maxsize=100, ttl=cache_ttl)
 
     def can_handle(self, source: Union[str, BytesIO]) -> bool:
-            file_type = None
-            try:
-                if isinstance(source, str):
-                    if not os.path.isfile(source):
-                        return False
-                    file_type = get_file_extension(source)
-                elif isinstance(source, BytesIO):
-                    source.seek(0)
-                    img = Image.open(source)
-                    file_type = img.format.lower()
-                    source.seek(0)
-                else:
-                    return False
-                return file_type.lower() in [fmt.lower() for fmt in self.SUPPORTED_FORMATS]
-            except Exception:
-                return False
+        """
+        Checks if the loader can handle the given source.
+        
+        Args:
+            source: Either a file path (str) or a BytesIO stream
             
+        Returns:
+            bool: True if the loader can handle the source, False otherwise
+        """
+        try:
+            if isinstance(source, str):
+                return self._can_handle_file_path(source)
+            elif isinstance(source, BytesIO):
+                return self._can_handle_stream(source)
+            return False
+        except Exception:
+            return False
+
+    def _can_handle_file_path(self, file_path: str) -> bool:
+        """Checks if the loader can handle the given file path."""
+        if not os.path.isfile(file_path):
+            return False
+        file_type = get_file_extension(file_path)
+        return file_type.lower() in [fmt.lower() for fmt in self.SUPPORTED_FORMATS]
+
+    def _can_handle_stream(self, stream: BytesIO) -> bool:
+        """Checks if the loader can handle the given BytesIO stream."""
+        try:
+            stream.seek(0)
+            img = Image.open(stream)
+            file_type = img.format.lower()
+            stream.seek(0)
+            return file_type.lower() in [fmt.lower() for fmt in self.SUPPORTED_FORMATS]
+        except Exception:
+            return False
+                
     @abstractmethod
     def load_content_from_file(self, file_path: str) -> Union[str, object]:
         pass

--- a/extract_thinker/document_loader/document_loader.py
+++ b/extract_thinker/document_loader/document_loader.py
@@ -42,6 +42,8 @@ class DocumentLoader(ABC):
         pass
 
     def load(self, source: Union[str, BytesIO]) -> Any:
+        if not self.can_handle(source):
+            raise ValueError("Unsupported file type or stream.")
         if isinstance(source, str):
             return self.load_content_from_file(source)
         elif isinstance(source, BytesIO):
@@ -69,6 +71,8 @@ class DocumentLoader(ABC):
         pass
 
     def convert_to_images(self, file: Union[str, io.BytesIO], scale: float = 300 / 72) -> Dict[int, bytes]:
+        if not self.can_handle(file):
+            raise ValueError("Unsupported file type or stream.")
         # Determine if the input is a file path or a stream
         if isinstance(file, str):
             return self._convert_file_to_images(file, scale)

--- a/extract_thinker/document_loader/document_loader_aws_textract.py
+++ b/extract_thinker/document_loader/document_loader_aws_textract.py
@@ -13,11 +13,9 @@ from extract_thinker.utils import get_file_extension, get_image_type, is_pdf_str
 
 from cachetools import cachedmethod
 from cachetools.keys import hashkey
-from queue import Queue
-
-SUPPORTED_IMAGE_FORMATS = ["jpeg", "png", "pdf"]
 
 class DocumentLoaderAWSTextract(CachedDocumentLoader):
+    SUPPORTED_FORMATS = ["jpeg", "png", "pdf", "tiff"]
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, region_name=None, textract_client=None, content=None, cache_ttl=300):
         super().__init__(content, cache_ttl)
         if textract_client:
@@ -42,7 +40,7 @@ class DocumentLoaderAWSTextract(CachedDocumentLoader):
             if is_pdf_stream(stream):
                 file_bytes = stream.getvalue() if isinstance(stream, BytesIO) else stream
                 return self.process_pdf(file_bytes)
-            elif get_image_type(stream) in SUPPORTED_IMAGE_FORMATS:
+            elif get_image_type(stream) in self.SUPPORTED_FORMATS:
                 file_bytes = stream.getvalue() if isinstance(stream, BytesIO) else stream
                 return self.process_image(file_bytes)
             else:
@@ -58,7 +56,7 @@ class DocumentLoaderAWSTextract(CachedDocumentLoader):
                 with open(file_path, 'rb') as file:
                     file_bytes = file.read()
                 return self.process_pdf(file_bytes)
-            elif file_type in SUPPORTED_IMAGE_FORMATS:
+            elif file_type in self.SUPPORTED_FORMATS:
                 with open(file_path, 'rb') as file:
                     file_bytes = file.read()
                 return self.process_image(file_bytes)

--- a/extract_thinker/document_loader/document_loader_azure_document_intelligence.py
+++ b/extract_thinker/document_loader/document_loader_azure_document_intelligence.py
@@ -10,6 +10,7 @@ from cachetools.keys import hashkey
 
 
 class DocumentLoaderAzureForm(CachedDocumentLoader):
+    SUPPORTED_FORMATS = ["pdf", "jpeg", "jpg", "png", "bmp", "tiff", "heif", "docx", "xlsx", "pptx", "html"]
     def __init__(self, subscription_key: str, endpoint: str, content: Any = None, cache_ttl: int = 300):
         super().__init__(content, cache_ttl)
         self.subscription_key = subscription_key

--- a/extract_thinker/document_loader/document_loader_pdfplumber.py
+++ b/extract_thinker/document_loader/document_loader_pdfplumber.py
@@ -6,15 +6,15 @@ import pdfplumber
 from extract_thinker.document_loader.cached_document_loader import CachedDocumentLoader
 from extract_thinker.utils import get_file_extension
 
-SUPPORTED_FORMATS = ['pdf']
-
 class DocumentLoaderPdfPlumber(CachedDocumentLoader):
+    SUPPORTED_FORMATS = ['pdf']
+
     def __init__(self, content: Any = None, cache_ttl: int = 300):
         super().__init__(content, cache_ttl)
 
     def load_content_from_file(self, file_path: str) -> Union[str, Dict[str, Any]]:
         try:
-            if get_file_extension(file_path).lower() not in SUPPORTED_FORMATS:
+            if get_file_extension(file_path).lower() not in self.SUPPORTED_FORMATS:
                 raise Exception(f"Unsupported file type: {file_path}")
 
             with pdfplumber.open(file_path) as pdf:

--- a/extract_thinker/document_loader/document_loader_pypdf.py
+++ b/extract_thinker/document_loader/document_loader_pypdf.py
@@ -3,9 +3,9 @@ from typing import Any, Dict, List, Union
 from pypdf import PdfReader
 from extract_thinker.document_loader.cached_document_loader import CachedDocumentLoader
 
-SUPPORTED_FORMATS = ['pdf']
-
 class DocumentLoaderPyPdf(CachedDocumentLoader):
+    SUPPORTED_FORMATS = ['pdf']
+    
     def __init__(self, content: Any = None, cache_ttl: int = 300):
         super().__init__(content, cache_ttl)
 

--- a/extract_thinker/document_loader/document_loader_spreadsheet.py
+++ b/extract_thinker/document_loader/document_loader_spreadsheet.py
@@ -7,9 +7,8 @@ from cachetools import cachedmethod
 from cachetools.keys import hashkey
 from extract_thinker.utils import get_file_extension
 
-SUPPORTED_FORMATS = ['xls', 'xlsx', 'xlsm', 'xlsb', 'odf', 'ods', 'odt', 'csv']
-
 class DocumentLoaderSpreadSheet(CachedDocumentLoader):
+    SUPPORTED_FORMATS = ['xls', 'xlsx', 'xlsm', 'xlsb', 'odf', 'ods', 'odt', 'csv']
 
     def __init__(self, content=None, cache_ttl=300):
         super().__init__(content, cache_ttl)

--- a/extract_thinker/document_loader/document_loader_tesseract.py
+++ b/extract_thinker/document_loader/document_loader_tesseract.py
@@ -14,10 +14,9 @@ from cachetools import cachedmethod
 from cachetools.keys import hashkey
 from queue import Queue
 
-SUPPORTED_IMAGE_FORMATS = ["jpeg", "png", "bmp", "tiff", "pdf"]
-
-
 class DocumentLoaderTesseract(CachedDocumentLoader):
+    SUPPORTED_FORMATS = ["jpeg", "png", "bmp", "tiff", "pdf"]
+    
     def __init__(self, tesseract_cmd, isContainer=False, content=None, cache_ttl=300):
         super().__init__(content, cache_ttl)
         self.tesseract_cmd = tesseract_cmd
@@ -36,7 +35,7 @@ class DocumentLoaderTesseract(CachedDocumentLoader):
                 with open(file_path, 'rb') as file:
                     return self.process_pdf(file)
             file_type = get_image_type(file_path)
-            if file_type in SUPPORTED_IMAGE_FORMATS:
+            if file_type in self.SUPPORTED_FORMATS:
                 image = Image.open(file_path)
                 raw_text = str(pytesseract.image_to_string(image))
                 self.content = raw_text
@@ -52,7 +51,7 @@ class DocumentLoaderTesseract(CachedDocumentLoader):
             if is_pdf_stream(stream):
                 return self.process_pdf(stream)
             file_type = get_image_type(stream)
-            if file_type in SUPPORTED_IMAGE_FORMATS:
+            if file_type in self.SUPPORTED_FORMATS:
                 image = Image.open(stream)
                 raw_text = str(pytesseract.image_to_string(image))
                 self.content = raw_text

--- a/tests/critical/test_critical_classification.py
+++ b/tests/critical/test_critical_classification.py
@@ -1,7 +1,4 @@
 import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
-
 from dotenv import load_dotenv
 from extract_thinker import Process
 from extract_thinker.document_loader.document_loader_pypdf import DocumentLoaderPyPdf

--- a/tests/critical/test_critical_extraction.py
+++ b/tests/critical/test_critical_extraction.py
@@ -2,7 +2,7 @@ import os
 from dotenv import load_dotenv
 from extract_thinker import Extractor
 from extract_thinker.document_loader.document_loader_pypdf import DocumentLoaderPyPdf
-from models.invoice import InvoiceContract
+from tests.models.invoice import InvoiceContract
 
 load_dotenv()
 cwd = os.getcwd()

--- a/tests/critical/test_critical_extraction.py
+++ b/tests/critical/test_critical_extraction.py
@@ -21,4 +21,4 @@ def test_critical_extract_with_pypdf():
     assert result.lines[0].description == "Consultation services"
     assert result.lines[0].quantity == 3
     assert result.lines[0].unit_price == 375
-    assert result.lines[0].amount == 1125 
+    assert result.lines[0].amount == 1125

--- a/tests/critical/test_critical_extraction.py
+++ b/tests/critical/test_critical_extraction.py
@@ -2,7 +2,7 @@ import os
 from dotenv import load_dotenv
 from extract_thinker import Extractor
 from extract_thinker.document_loader.document_loader_pypdf import DocumentLoaderPyPdf
-from tests.models.invoice import InvoiceContract
+from models.invoice import InvoiceContract
 
 load_dotenv()
 cwd = os.getcwd()

--- a/tests/critical/test_critical_extraction.py
+++ b/tests/critical/test_critical_extraction.py
@@ -1,7 +1,4 @@
 import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
-
 from dotenv import load_dotenv
 from extract_thinker import Extractor
 from extract_thinker.document_loader.document_loader_pypdf import DocumentLoaderPyPdf


### PR DESCRIPTION
Related to #58

Add `can_handle` logic to `DocumentLoader` class in `extract_thinker/document_loader/document_loader.py`.

* Add `can_handle` check in `load` method to raise a `ValueError` if the file type or stream is unsupported.
* Add `can_handle` check in `convert_to_images` method to raise a `ValueError` if the file type or stream is unsupported.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/enoch3712/ExtractThinker/pull/74?shareId=6b327c33-d1c8-4c82-a64a-931ac8d07fa1).