### PR TITLE
fix(extract_thinker.markdown.markdown_converter): prevent using visio…

### DIFF
--- a/extract_thinker/markdown/markdown_converter.py
+++ b/extract_thinker/markdown/markdown_converter.py
@@ -556,9 +556,9 @@ Your response should ONLY include the formatted Markdown content without any add
                  # We have both LLM and DocumentLoader
                  
                  # Configure document loader for vision if needed
-                 if vision and hasattr(self.document_loader, 'set_vision_mode'):
+                 if hasattr(self.document_loader, 'set_vision_mode'):
                      try:
-                         self.document_loader.set_vision_mode(True)
+                         self.document_loader.set_vision_mode(vision)
                      except Exception as e:
                          print(f"Warning: Failed to set vision mode on document loader: {e}")
                  
@@ -697,9 +697,9 @@ Your response should ONLY include the formatted Markdown content without any add
                  raise ValueError("Document loader is required.")
 
             # Configure document loader for vision if needed and supported
-            if vision and hasattr(self.document_loader, 'set_vision_mode'):
+            if hasattr(self.document_loader, 'set_vision_mode'):
                 try:
-                    self.document_loader.set_vision_mode(True)
+                    self.document_loader.set_vision_mode(vision)
                 except Exception as e:
                     print(f"Warning: Failed to set vision mode on document loader: {e}")
 


### PR DESCRIPTION
fix(extract_thinker.markdown.markdown_converter): prevent using vision (if set False) after using it as True

```
loader = DocumentLoaderPyPdf()
llm = LLM(model_name)
markdown_converter = MarkdownConverter(document_loader=loader, llm=llm)

markdown_converter.to_markdown(source_path, vision=True, pages=[1])
markdown_converter.to_markdown(source_path, vision=False, pages=[1]) # Before the fix, this was still executed as vision=True
```

